### PR TITLE
Fix FutureWarning by importing anndata read_* functions from anndata.io

### DIFF
--- a/simba/plotting/_plot.py
+++ b/simba/plotting/_plot.py
@@ -89,11 +89,11 @@ def violin(adata,
     if list_var is None:
         list_var = []
     for obs in list_obs:
-        if obs not in adata.obs_keys():
-            raise ValueError(f"could not find {obs} in `adata.obs_keys()`")
+        if obs not in adata.obs:
+            raise ValueError(f"could not find {obs} in `adata.obs`")
     for var in list_var:
-        if var not in adata.var_keys():
-            raise ValueError(f"could not find {var} in `adata.var_keys()`")
+        if var not in adata.var:
+            raise ValueError(f"could not find {var} in `adata.var`")
     if len(list_obs) > 0:
         df_plot = adata.obs[list_obs].copy()
         if log:
@@ -234,11 +234,11 @@ def hist(adata,
     if list_var is None:
         list_var = []
     for obs in list_obs:
-        if obs not in adata.obs_keys():
-            raise ValueError(f"could not find {obs} in `adata.obs_keys()`")
+        if obs not in adata.obs:
+            raise ValueError(f"could not find {obs} in `adata.obs`")
     for var in list_var:
-        if var not in adata.var_keys():
-            raise ValueError(f"could not find {var} in `adata.var_keys()`")
+        if var not in adata.var:
+            raise ValueError(f"could not find {var} in `adata.var`")
 
     if len(list_obs) > 0:
         df_plot = adata.obs[list_obs].copy()
@@ -1056,10 +1056,10 @@ def umap(adata,
     else:
         color = list(dict.fromkeys(color))  # remove duplicate keys
         for ann in color:
-            if ann in adata.obs_keys():
+            if ann in adata.obs:
                 df_plot[ann] = adata.obs[ann]
                 if not is_numeric_dtype(df_plot[ann]):
-                    if 'color' not in adata.uns_keys():
+                    if 'color' not in adata.uns:
                         adata.uns['color'] = dict()
 
                     if ann not in dict_palette.keys():
@@ -1178,7 +1178,7 @@ def discretize(adata,
     if fig_path is None:
         fig_path = os.path.join(settings.workdir, 'figures')
 
-    assert 'disc' in adata.uns_keys(), \
+    assert 'disc' in adata.uns, \
         "please run `si.tl.discretize()` first"
     if kde is not None:
         warnings.warn("kde is no longer supported as of v1.1",
@@ -1437,7 +1437,7 @@ def svd_nodes(adata,
     else:
         color = list(dict.fromkeys(color))  # remove duplicate keys
     for ann in color:
-        if (ann in adata.obs_keys()) and (ann in adata.var_keys()):
+        if (ann in adata.obs) and (ann in adata.var):
             df_plot[ann] = pd.concat([adata.obs[ann], adata.var[ann]], axis=0)
             if not is_numeric_dtype(df_plot[ann]):
                 if ann not in dict_palette.keys():

--- a/simba/plotting/_post_training.py
+++ b/simba/plotting/_post_training.py
@@ -609,10 +609,10 @@ def query(adata,
     else:
         color = list(dict.fromkeys(color))  # remove duplicate keys
         for ann in color:
-            if ann in adata.obs_keys():
+            if ann in adata.obs:
                 df_plot[ann] = adata.obs[ann]
                 if not is_numeric_dtype(df_plot[ann]):
-                    if 'color' not in adata.uns_keys():
+                    if 'color' not in adata.uns:
                         adata.uns['color'] = dict()
 
                     if ann not in dict_palette.keys():

--- a/simba/preprocessing/_qc.py
+++ b/simba/preprocessing/_qc.py
@@ -195,17 +195,17 @@ def filter_samples(adata,
 
     if not issparse(adata.X):
         adata.X = csr_matrix(adata.X)
-    if 'n_counts' in adata.obs_keys():
+    if 'n_counts' in adata.obs:
         n_counts = adata.obs['n_counts']
     else:
         n_counts = np.sum(adata.X, axis=1).A
         adata.obs['n_counts'] = n_counts
-    if 'n_features' in adata.obs_keys():
+    if 'n_features' in adata.obs:
         n_features = adata.obs['n_features']
     else:
         n_features = np.sum(adata.X >= expr_cutoff, axis=1).A1
         adata.obs['n_features'] = n_features
-    if 'pct_features' in adata.obs_keys():
+    if 'pct_features' in adata.obs:
         pct_features = adata.obs['pct_features']
     else:
         pct_features = n_features/adata.shape[1]
@@ -290,18 +290,18 @@ def filter_cells_rna(adata,
 
     if not issparse(adata.X):
         adata.X = csr_matrix(adata.X)
-    if 'n_counts' in adata.obs_keys():
+    if 'n_counts' in adata.obs:
         n_counts = adata.obs['n_counts']
     else:
         n_counts = np.sum(adata.X, axis=1).A1
         adata.obs['n_counts'] = n_counts
 
-    if 'n_genes' in adata.obs_keys():
+    if 'n_genes' in adata.obs:
         n_genes = adata.obs['n_genes']
     else:
         n_genes = np.sum(adata.X >= expr_cutoff, axis=1).A1
         adata.obs['n_genes'] = n_genes
-    if 'pct_genes' in adata.obs_keys():
+    if 'pct_genes' in adata.obs:
         pct_genes = adata.obs['pct_genes']
     else:
         pct_genes = n_genes/adata.shape[1]
@@ -386,18 +386,18 @@ def filter_cells_atac(adata,
 
     if not issparse(adata.X):
         adata.X = csr_matrix(adata.X)
-    if 'n_counts' in adata.obs_keys():
+    if 'n_counts' in adata.obs:
         n_counts = adata.obs['n_counts']
     else:
         n_counts = np.sum(adata.X, axis=1).A1
         adata.obs['n_counts'] = n_counts
 
-    if 'n_peaks' in adata.obs_keys():
+    if 'n_peaks' in adata.obs:
         n_peaks = adata.obs['n_peaks']
     else:
         n_peaks = np.sum(adata.X >= expr_cutoff, axis=1).A1
         adata.obs['n_peaks'] = n_peaks
-    if 'pct_peaks' in adata.obs_keys():
+    if 'pct_peaks' in adata.obs:
         pct_peaks = adata.obs['pct_peaks']
     else:
         pct_peaks = n_peaks/adata.shape[1]
@@ -481,17 +481,17 @@ def filter_genes(adata,
     if not issparse(adata.X):
         adata.X = csr_matrix(adata.X)
 
-    if 'n_counts' in adata.var_keys():
+    if 'n_counts' in adata.var:
         n_counts = adata.var['n_counts']
     else:
         n_counts = np.sum(adata.X, axis=0).A1
         adata.var['n_counts'] = n_counts
-    if 'n_cells' in adata.var_keys():
+    if 'n_cells' in adata.var:
         n_cells = adata.var['n_cells']
     else:
         n_cells = np.sum(adata.X >= expr_cutoff, axis=0).A1
         adata.var['n_cells'] = n_cells
-    if 'pct_cells' in adata.var_keys():
+    if 'pct_cells' in adata.var:
         pct_cells = adata.var['pct_cells']
     else:
         pct_cells = n_cells/adata.shape[0]
@@ -572,17 +572,17 @@ def filter_peaks(adata,
     if not issparse(adata.X):
         adata.X = csr_matrix(adata.X)
 
-    if 'n_counts' in adata.var_keys():
+    if 'n_counts' in adata.var:
         n_counts = adata.var['n_counts']
     else:
         n_counts = np.sum(adata.X, axis=0).A1
         adata.var['n_counts'] = n_counts
-    if 'n_cells' in adata.var_keys():
+    if 'n_cells' in adata.var:
         n_cells = adata.var['n_cells']
     else:
         n_cells = np.sum(adata.X >= expr_cutoff, axis=0).A1
         adata.var['n_cells'] = n_cells
-    if 'pct_cells' in adata.var_keys():
+    if 'pct_cells' in adata.var:
         pct_cells = adata.var['pct_cells']
     else:
         pct_cells = n_cells/adata.shape[0]
@@ -661,17 +661,17 @@ def filter_features(adata,
 
     if not issparse(adata.X):
         adata.X = csr_matrix(adata.X)
-    if 'n_counts' in adata.var_keys():
+    if 'n_counts' in adata.var:
         n_counts = adata.var['n_counts']
     else:
         n_counts = np.sum(adata.X, axis=0).A1
         adata.var['n_counts'] = n_counts
-    if 'n_samples' in adata.var_keys():
+    if 'n_samples' in adata.var:
         n_samples = adata.var['n_samples']
     else:
         n_samples = np.sum(adata.X >= expr_cutoff, axis=0).A1
         adata.var['n_samples'] = n_samples
-    if 'pct_samples' in adata.var_keys():
+    if 'pct_samples' in adata.var:
         pct_samples = adata.var['pct_samples']
     else:
         pct_samples = n_samples/adata.shape[0]

--- a/simba/readwrite.py
+++ b/simba/readwrite.py
@@ -224,10 +224,10 @@ def write_bed(adata,
     if filename is None:
         filename = os.path.join(settings.workdir, 'peaks.bed')
     for x in ['chr', 'start', 'end']:
-        if x not in adata.var_keys():
-            raise ValueError(f"could not find {x} in `adata.var_keys()`")
+        if x not in adata.var:
+            raise ValueError(f"could not find {x} in `adata.var`")
     if use_top_pcs:
-        assert 'top_pcs' in adata.var_keys(), \
+        assert 'top_pcs' in adata.var, \
             "please run `si.pp.select_pcs_features()` first"
         peaks_selected = adata.var[
             adata.var['top_pcs']][['chr', 'start', 'end']]

--- a/simba/readwrite.py
+++ b/simba/readwrite.py
@@ -3,18 +3,33 @@
 import os
 import pandas as pd
 import json
-from anndata import (
-    AnnData,
-    read_h5ad,
-    read_csv,
-    read_excel,
-    read_hdf,
-    read_loom,
-    read_mtx,
-    read_text,
-    read_umi_tools,
-    read_zarr,
-)
+from anndata import AnnData
+try:
+    # New anndata
+    from anndata.io import (
+        read_h5ad,
+        read_csv,
+        read_excel,
+        read_hdf,
+        read_loom,
+        read_mtx,
+        read_text,
+        read_umi_tools,
+        read_zarr,
+    )
+except ImportError:
+    # Old anndata fallback
+    from anndata import (
+        read_h5ad,
+        read_csv,
+        read_excel,
+        read_hdf,
+        read_loom,
+        read_mtx,
+        read_text,
+        read_umi_tools,
+        read_zarr,
+    )
 from pathlib import Path
 import tables
 

--- a/simba/tools/_gene_scores.py
+++ b/simba/tools/_gene_scores.py
@@ -160,7 +160,7 @@ class GeneScores:
             mask_p = pd.Series(True, index=adata.var_names)
         df_peaks = adata.var[mask_p][['chr', 'start', 'end']].copy()
 
-        if 'gene_scores' not in adata.uns_keys():
+        if 'gene_scores' not in adata.uns:
             print('Gene scores are being calculated for the first time')
             print('`use_precomputed` has been ignored')
             self.use_precomputed = False

--- a/simba/tools/_post_training.py
+++ b/simba/tools/_post_training.py
@@ -369,7 +369,7 @@ def query(adata,
         <https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.DistanceMetric.html>`__"
     anno_filter : `str`, optional (default: None)
         The annotation of filter to use.
-        It should be one of ``adata.obs_keys()``
+        It should be one of ``adata.obs.columns``
     filters : `list`, optional (default: None)
         The filters to use.
         It should be a list of values in ``adata.obs[anno_filter]``
@@ -440,7 +440,7 @@ def query(adata,
             df_output = pd.concat(
                 [df_output, df_output_ii], ignore_index=False)
         if anno_filter is not None:
-            if anno_filter in adata.obs_keys():
+            if anno_filter in adata.obs:
                 if filters is None:
                     filters = df_output[anno_filter].unique().tolist()
                 df_output.query(f'{anno_filter} == @filters', inplace=True)
@@ -451,7 +451,7 @@ def query(adata,
         # assert (metric in ['euclidean', 'dot_product']),\
         #             "`metric` must be one of ['euclidean','dot_product']"
         if anno_filter is not None:
-            if anno_filter in adata.obs_keys():
+            if anno_filter in adata.obs:
                 if filters is None:
                     filters = adata.obs[anno_filter].unique().tolist()
                 ids_filters = \
@@ -538,7 +538,7 @@ def find_master_regulators(adata_all,
         ‘sokalmichener’, ‘sokalsneath’, ‘sqeuclidean’, ‘wminkowski’, ‘yule’.
     anno_filter : `str`, optional (default: None)
         The annotation of filter to use.
-        It should be one of ``adata.obs_keys()``
+        It should be one of ``adata.obs.columns``
     filter_gene : `str`, optional (default: None)
         The filter for gene.
         It should be in ``adata.obs[anno_filter]``
@@ -686,7 +686,7 @@ def find_target_genes(adata_all,
         ‘sokalmichener’, ‘sokalsneath’, ‘sqeuclidean’, ‘wminkowski’, ‘yule’.
     anno_filter : `str`, optional (default: None)
         The annotation of filter to use.
-        It should be one of ``adata.obs_keys()``
+        It should be one of ``adata.obs.columns``
     filter_gene : `str`, optional (default: None)
         The filter for gene.
         It should be in ``adata.obs[anno_filter]``
@@ -730,7 +730,7 @@ def find_target_genes(adata_all,
         return np.array([item in b for item in a])
 
     print('Preprocessing ...')
-    if use_precomputed and 'tf_targets' in adata_all.uns_keys():
+    if use_precomputed and 'tf_targets' in adata_all.uns:
         print('importing precomputed variables ...')
         genes = adata_all.uns['tf_targets']['genes']
         peaks = adata_all.uns['tf_targets']['peaks']
@@ -741,7 +741,7 @@ def find_target_genes(adata_all,
         assert (adata_CP is not None), \
             '`adata_CP` needs to be specified '\
             'when no precomputed variable is stored'
-        if 'gene_scores' not in adata_CP.uns_keys():
+        if 'gene_scores' not in adata_CP.uns:
             print('Please run "si.tl.gene_scores(adata_CP)" first.')
         else:
             overlap_PG = adata_CP.uns['gene_scores']['overlap'].copy()


### PR DESCRIPTION
### Problem

With recent versions of `anndata`, importing `read_*` functions from the top-level
`anndata` module triggers a `FutureWarning`, as these functions have been moved
to `anndata.io`.

This warning currently appears when importing SIMBA on environments with newer
`anndata` versions.

### Changes

- Import `read_*` functions from `anndata.io` instead of the top-level `anndata`
- Keep a fallback to the old import path for compatibility with older `anndata`
  versions
